### PR TITLE
chore: add secret scanning paths-ignore for bundled dist artifacts

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "dist/**"


### PR DESCRIPTION
## Summary

Add `.github/secret_scanning.yml` to suppress secret-scanning alerts on `dist/**`. The bundled GitHub Action artifacts (`dist/index.js.map`, `dist/licenses.txt`) bundle 3rd-party maintainer emails from every dep's `package.json`, so every dependency bump reintroduces ~12 `pii_email_address` alerts.

Part of the 2026-05-26 org-wide security triage cleanup.

## Caveat

GitHub's docs are ambiguous about whether `paths-ignore` covers default secret-scanning patterns. Low-risk experiment.

## Test plan

- [ ] Merge and wait for next scan cycle
- [ ] Verify alerts on `dist/**` close
- [ ] If not, revert + bulk-dismiss