### PR TITLE
Add sensitive data scanning with gitleaks

### DIFF
--- a/.github/workflows/sensitive-data-scan.yaml
+++ b/.github/workflows/sensitive-data-scan.yaml
@@ -1,0 +1,83 @@
+name: Sensitive Data Scan
+
+# Standalone copy of the org sensitive-data scan.
+#
+# This repository is PUBLIC, and GitHub does not allow public repositories to
+# call reusable workflows that live in internal/private repositories, so we
+# cannot use moneyforward-i/actions/.github/workflows/reusable-sensitive-data-scan.yaml
+# like private repos do. The steps below mirror that reusable workflow's
+# pull_request ("diff") scan path; keep them in sync when the reusable changes.
+# Canonical source: moneyforward-i/actions (reusable-sensitive-data-scan).
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository (full history for commit-range scans)
+    steps:
+      - name: Check out repository (full history)
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          curl -sSfL --retry 3 -o "$RUNNER_TEMP/gitleaks.tar.gz" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  $RUNNER_TEMP/gitleaks.tar.gz" | sha256sum -c -
+          mkdir -p "$RUNNER_TEMP/gitleaks-bin"
+          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP/gitleaks-bin" gitleaks
+          echo "$RUNNER_TEMP/gitleaks-bin" >> "$GITHUB_PATH"
+
+      - name: Run gitleaks
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPORT_PATH: ${{ runner.temp }}/gitleaks-report.json
+        run: |
+          set -euo pipefail
+          echo "Scanning commit range $PR_BASE_SHA..$PR_HEAD_SHA"
+          gitleaks git --log-opts="--no-merges $PR_BASE_SHA..$PR_HEAD_SHA" \
+            --config .gitleaks.toml --redact --no-banner --exit-code 1 \
+            --report-format json --report-path "$REPORT_PATH" --verbose .
+
+      - name: Write step summary
+        if: always()
+        env:
+          REPORT_PATH: ${{ runner.temp }}/gitleaks-report.json
+        run: |
+          set -euo pipefail
+          {
+            echo "## Sensitive Data Scan"
+            if [ ! -f "$REPORT_PATH" ]; then
+              echo "Scan did not produce a report (setup failure)."
+            elif [ "$(jq 'length' "$REPORT_PATH")" -eq 0 ]; then
+              echo "No sensitive data found. :white_check_mark:"
+            else
+              echo "**$(jq 'length' "$REPORT_PATH") finding(s).** Real client/employee data must be removed and the secret rotated; placeholder data should use \`example.com\` / \`.test\` domains."
+              echo
+              echo "| Rule | File | Line | Description |"
+              echo "|---|---|---|---|"
+              jq -r '.[] | "| \(.RuleID) | \(.File) | \(.StartLine) | \(.Description) |"' "$REPORT_PATH"
+              echo
+              echo "False positive? Add its fingerprint to \`.gitleaksignore\`, or extend the allowlist in the repo's \`.gitleaks.toml\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gitleaks-report
+          path: ${{ runner.temp }}/gitleaks-report.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,92 @@
+title = "moneyforward-i sensitive-data baseline"
+
+# Org-wide gitleaks baseline for moneyforward-i repositories.
+# Extends the stock gitleaks rules (secrets: API keys, tokens, private
+# keys, ...) with PII rules: client/employee email addresses must never
+# be committed as code.
+#
+# Repo-local copy of the org baseline, used by both CI (the
+# reusable-sensitive-data-scan workflow prefers this file) and the local
+# pre-commit hook. Canonical source: moneyforward-i/actions
+#   .github/workflows/reusable-sensitive-data-scan/config/gitleaks-org.toml
+# Add repo-specific allowlists at the bottom of this file; do not weaken
+# the org rules.
+
+[extend]
+useDefault = true
+
+# -------------------------------------------------------------------
+# Money Forward internal / employee email addresses
+# -------------------------------------------------------------------
+[[rules]]
+id = "moneyforward-email-address"
+description = "Money Forward internal email address committed as code"
+regex = '''(?i)\b[a-z0-9._%+-]+@(?:i\.)?moneyforward(?:-dev)?\.(?:com|co\.jp|vn)\b'''
+tags = ["pii", "email", "internal"]
+
+  [[rules.allowlists]]
+  description = "Public role addresses are not PII"
+  regexTarget = "match"
+  regexes = ['''(?i)\b(?:support|info|noreply|no-reply|contact|sales|press|privacy|security|legal)@''']
+
+# -------------------------------------------------------------------
+# Any other real-looking email address (catches client/customer PII)
+# -------------------------------------------------------------------
+[[rules]]
+id = "generic-email-address"
+description = "Email address on a non-placeholder domain (possible client/employee PII)"
+regex = '''(?i)\b[a-z][a-z0-9._%+-]*@[a-z0-9][a-z0-9.-]*\.[a-z]{2,}\b'''
+tags = ["pii", "email"]
+
+  [[rules.allowlists]]
+  description = "RFC 2606 / RFC 6761 reserved and conventional placeholder domains"
+  regexTarget = "match"
+  regexes = [
+    '''(?i)@(?:[a-z0-9.-]+\.)?example\.(?:com|org|net|jp|co\.jp)\b''',
+    '''(?i)@(?:[a-z0-9.-]+\.)?(?:example|test|invalid|localhost|local)\b''',
+    '''(?i)@(?:test|testing|sample|dummy|placeholder|fake|mail|email|domain|company|acme|acme-corp|admina)\.(?:com|org|net|io|jp|co\.jp|test)\b''',
+    '''(?i)@[a-z0-9.-]*test[a-z0-9-]*\.(?:com|org|net|io|jp|co\.jp)\b''',
+    '''(?i)@(?:foo|bar|baz|qux|hoge|fuga|piyo|abc|xyz)\.[a-z.]{2,}\b''',
+    '''(?i)@[a-z]\.(?:com|org|net|io|jp|co\.jp)\b''',
+    '''(?i)@[\w.-]+\.(?:png|jpe?g|gif|svg|webp|md|ts|tsx|js|json|ya?ml)\b''',
+    '''(?i)@users\.noreply\.github\.com\b''',
+    '''(?i)\b(?:noreply|no-reply|donotreply|support|info|contact|sales|press|privacy|security|legal)@''',
+    '''@\d''',
+    '''(?i)@[a-z0-9-]+(?:\.[a-z0-9-]+)*\.i\.moneyforward\.com\b''',
+    '''(?i)@admina\.moneyforward\.com\b''',
+  ]
+
+  [[rules.allowlists]]
+  description = "Dependency metadata and generated artifacts (OSS author emails etc.)"
+  paths = [
+    '''(?:^|/)node_modules/''',
+    '''(?:^|/)\.yarn/''',
+    '''yarn\.lock$''',
+    '''package-lock\.json$''',
+    '''pnpm-lock\.yaml$''',
+    '''Gemfile\.lock$''',
+    '''go\.sum$''',
+    '''(?:^|/)LICENSE(?:\.[a-z]+)?$''',
+  ]
+
+# -------------------------------------------------------------------
+# Global allowlist
+# -------------------------------------------------------------------
+[[allowlists]]
+description = "Vendored, generated, and lock content never reviewed by hand; scanner's own config/docs (contain detection examples)"
+paths = [
+  '''(?:^|/)node_modules/''',
+  '''(?:^|/)\.yarn/(?:cache|releases|plugins)/''',
+  '''(?:^|/)dist/''',
+  '''(?:^|/)\.next/''',
+  '''(?:^|/)docs/security/[^/]*triage[^/]*\.md$''',
+  '''(?:^|/)\.gitleaks\.toml$''',
+  '''(?:^|/)\.gitleaksignore$''',
+  '''(?:^|/)\.github/workflows/reusable-sensitive-data-scan/''',
+  '''\.(?:png|jpe?g|gif|ico|webp|woff2?|ttf|eot|pdf|zip|gz)$''',
+]
+
+# ---------------------------------------------------------------------------
+# Repo-specific allowlists (add entries below; prefer .gitleaksignore for
+# one-off false positives)
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Prevent accidental commits of secrets (API keys, tokens, private keys) and PII (client/employee email addresses). This is the org-wide rollout of moneyforward-i/vulcan#7940.

## Changelog

- Add root `.gitleaks.toml` with the org baseline rules (`moneyforward-email-address` + `generic-email-address` on top of the stock gitleaks secret rules), including placeholder-domain allowlists and a global allowlist for vendored/generated content (`node_modules/`, `dist/`, binary assets).
- Add `.github/workflows/sensitive-data-scan.yaml`. Note: this repository is **public**, and GitHub does not allow public repos to call reusable workflows hosted in internal/private repos, so instead of calling `moneyforward-i/actions/.github/workflows/reusable-sensitive-data-scan.yaml` (the pattern used in private repos), this is a standalone workflow that mirrors the reusable's PR commit-range scan: pinned gitleaks 8.30.1 with SHA-256 verification, `--redact`, JSON report artifact, and step summary. Keep it in sync with the canonical reusable in `moneyforward-i/actions`.
- No local pre-commit hook added: this repo uses no hook manager (no husky/lefthook/pre-commit), so scanning is covered by CI only.

## How to test

- `brew install gitleaks`
- Create a scratch file containing `test@moneyforward.com` and run `gitleaks dir <dir> --config .gitleaks.toml --no-banner --exit-code 1` — it must report a leak; `test@example.com` must pass.
- Verify the "Sensitive Data Scan" check runs on this PR.